### PR TITLE
Log in with Telegram

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/components/ui/TelegramLoginButton.tsx
+++ b/src/components/ui/TelegramLoginButton.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { setTelegramAuthData } from '@/lib/auth/token';
+import { LoginButton } from '@telegram-auth/react';
+import { TelegramAuthData } from "@telegram-auth/react";
+
+export default function TelegramLoginButton() {
+    return (
+        <div className="App">
+            <LoginButton
+                botUsername={process.env.TELEGRAM_BOT_USERNAME}
+                onAuthCallback={(data) => {
+                    console.log(data);
+                    setTelegramAuthData(data);
+                    window.location.replace("/dashboard");
+                }}
+            />
+        </div>
+    );
+}

--- a/src/components/ui/menus/User.tsx
+++ b/src/components/ui/menus/User.tsx
@@ -5,6 +5,7 @@ import { ArrowRightEndOnRectangleIcon } from "@heroicons/react/24/solid";
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import TelegramLoginButton from "@/components/ui/TelegramLoginButton"
 
 export default function UserMenu({ type = "only-icon" }: { type?: "only-icon" | "secondary" }) {
     const t = useTranslations("Common.auth");
@@ -20,12 +21,7 @@ export default function UserMenu({ type = "only-icon" }: { type?: "only-icon" | 
     return (
         <>
             {user ? null : (
-                <a href="/dashboard">
-                    <button className="primary">
-                        {type !== "only-icon" ? t("signin") : ""}
-                        <ArrowRightEndOnRectangleIcon />
-                    </button>
-                </a>
+                <TelegramLoginButton/>
             )}
         </>
     );


### PR DESCRIPTION
Replaces "Sign in" button with the default "Log in with Telegram" button.
The TELEGRAM_BOT_USERNAME env variable must be set appropriately.
Please note that the widget only works with a valid domain set for the bot, and when accessed via HTTPS (requires a reverse proxy with TLS management).